### PR TITLE
Adds WH build, learn, and index page templates

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+  - tables
 
 plugins:
   - search

--- a/papermoon-docs/.snippets/code/style-guide/key-resources/templates/wormhole/index-pages/wh-build-template.md
+++ b/papermoon-docs/.snippets/code/style-guide/key-resources/templates/wormhole/index-pages/wh-build-template.md
@@ -1,0 +1,51 @@
+```
+---
+title: {{34 - 44 character SEO-friendly title}}
+description: {{120 - 160 charater SEO-friendly description}}
+---
+
+# {{Page Title to Display on Page}}
+
+## Introduction
+
+{{clear description of the task completed in the guide, when and why to perform the task}}
+
+## Prerequisites
+
+This guide assumes knowledge of basic blockchain development and Wormhole concepts. To successfully follow this guide, you will need:
+
+- {{Wormhole concepts beyond the basics - link to Learn pages}}
+- {{Software or hardware requirements - link to Installation pages where possible}}
+- {{Environments to set up and configure - link to any related resources}}
+- {{Testnet tokens or wallets - links to faucets or wallets}}
+- {{Authentication and authorization such as API keys, private key, etc. - link to get credentials}}
+
+## {{Name of first subtask - Create a New Folder, Install the Package, Clone the Repository}}
+
+{{Brief explanatory text if needed}}
+
+1. {{Describe action to take - start with a base, plain verb}}
+
+INSERT_SNIPPET_SYNTAX (if using a code example)
+
+{{Include related result information if needed (terminal outputs, success messages, and similar)}}
+
+## {{Name of second subtask}}
+
+{{Brief explanatory text if needed}}
+
+2. {{Describe action to take - start with a base, plain verb}}
+
+INSERT_SCREENSHOT_SYNTAX (if using a screenshot)
+
+{{Include related result information if needed (terminal outputs, success messages, and similar)}}
+
+## Related Resources
+
+- {{For more information about {{topic}}, see the [{{Title}}]({{path/for/link}}) page of this documentation}}
+- {{To review the {{tool name}} source code, see the [{{repo name}}]({{path/for/link}}) repository on GitHub}}
+
+## Where to Go Next
+- {{For a guide to integrating {{Product}} with your project, see [{{How-to-Integrate-Product}}]({{path/for/link}}) in the Build section}}
+- {{For a step-by-step walk-through of configuring {{Tool}}, see [{{Tutorial Title}}]({{path/for/link}}) in the Tutorials section}}
+```

--- a/papermoon-docs/.snippets/code/style-guide/key-resources/templates/wormhole/index-pages/wh-index-template.md
+++ b/papermoon-docs/.snippets/code/style-guide/key-resources/templates/wormhole/index-pages/wh-index-template.md
@@ -26,5 +26,5 @@ description: {{120 - 160 charater SEO-friendly description}}
 {{Optional, include where it makes sense. Provided copy is example wording}}
 ## Where to Go Next
 - {{For a guide to integrating {{Product}} with your project, see [{{How-to-Integrate-Product}}]({{path/for/link}}) in the Build section}}
-- {{For a step-by-step walk-through of configuring {{Tool}}, see {{Tutorial Title}} in the Tutorials section}}
+- {{For a step-by-step walk-through of configuring {{Tool}}, see [{{Tutorial Title}}]({{path/for/link}}) in the Tutorials section}}
 ```

--- a/papermoon-docs/.snippets/code/style-guide/key-resources/templates/wormhole/index-pages/wh-index-template.md
+++ b/papermoon-docs/.snippets/code/style-guide/key-resources/templates/wormhole/index-pages/wh-index-template.md
@@ -20,13 +20,11 @@ description: {{120 - 160 charater SEO-friendly description}}
 
 {{Optional, include where it makes sense. Provided copy is example wording}}
 ## Related Resources
-
 - {{For more information about {{topic}}, see the [{{Title}}]({{path/for/link}}) page of this documentation}}
 - {{To review the {{tool name}} source code, see the [{{repo name}}]({{path/for/link}}) repository on GitHub}}
 
 {{Optional, include where it makes sense. Provided copy is example wording}}
 ## Where to Go Next
-
 - {{For a guide to integrating {{Product}} with your project, see [{{How-to-Integrate-Product}}]({{path/for/link}}) in the Build section}}
-- {{For a step-by-step walk-through of configuring {{Tool}}, see [{{Tutorial Title}}]({{path/for/link}}) in the Tutorials section}}
+- {{For a step-by-step walk-through of configuring {{Tool}}, see {{Tutorial Title}} in the Tutorials section}}
 ```

--- a/papermoon-docs/.snippets/code/style-guide/key-resources/templates/wormhole/index-pages/wh-learn-template.md
+++ b/papermoon-docs/.snippets/code/style-guide/key-resources/templates/wormhole/index-pages/wh-learn-template.md
@@ -1,0 +1,38 @@
+```
+---
+title: {{34 - 44 character SEO-friendly title}}
+description: {{120 - 160 charater SEO-friendly description}}
+---
+
+# {{Page Title to Display on Page}}
+
+## Introduction
+
+{{Opening paragraph}}
+
+{{One to two additional paragraphs - define the concept, functionality, big picture, and key features}}
+
+{{Optional visual aid or diagram}}
+
+## Use Cases
+
+{{Include a brief explanation of the problem being solved and specifically how the presented concept solves the problem}}
+
+## Comparing to {{ name of the thing your're comparing to this concept }} 
+
+{{ Optional, include where it makes sense. Use a comparison table here or link the user to a comparison table elsewhere on the site }}
+
+## How it Works
+
+{{ One to two paragraphs to briefly explain how the concept operates and the main components involved in any associated process }}
+
+
+## Related Resources
+
+- {{For more information about {{topic}}, see the [{{Title}}]({{path/for/link}}) page of this documentation}}
+- {{To review the {{tool name}} source code, see the [{{repo name}}]({{path/for/link}}) repository on GitHub}}
+
+## Where to Go Next
+- {{For a guide to integrating {{Product}} with your project, see [{{How-to-Integrate-Product}}]({{path/for/link}}) in the Build section}}
+- {{For a step-by-step walk-through of configuring {{Tool}}, see [{{Tutorial Title}}]({{path/for/link}}) in the Tutorials section}}
+```

--- a/papermoon-docs/style-guide/key-resources/templates/index.md
+++ b/papermoon-docs/style-guide/key-resources/templates/index.md
@@ -13,17 +13,51 @@ In this section you will find templates for the four primary documenation types 
 
 ## How-To Use the Templates
 
-Deciding which template best fits the content you want to create can be tricky, especially when it comes to differentiating tutorials from how-to guides.
-
-## Available Templates
+Deciding which template best fits the content you want to create can be tricky, especially when it comes to differentiating tutorials from how-to guides. The following sections provide guidance for selecting the best template category with links to available templates by project. 
 
 ### Concept
 
+The concept template is used for informational pages intended to increase the user's understanding of a topic. Concept pages are typically grouped together into a section. Some example concept section names per project are as follows:
+
+| Project  | Concept page section |
+|:---------|:---------------------|
+| Moonbeam | Learn                |
+| Polkadot | Polkadot Protocol    |
+| Tanssi   | Learn                |
+| Wormhole | Learn                |
+
+#### Wormhole
+
+- [**Learn page template guide**](/papermoon-mkdocs/style-guide/key-resources/templates/wormhole/learn-pages/)
+- [**Learn page template**](/papermoon-mkdocs/style-guide/key-resources/templates/wormhole/learn-pages/#learn-page-template)
+
 ### How-To Guide
+
+The how-to guide template is used for instructional pages meant to help the user solve a real-world problem or complete a task. 
+
+It can be helpful to think about cooking when deciding between a how-to guide and tutorial. If someone already knows how to cook, they can use a recipe as long as it has a complete list of what they need (ingredients, equipment) and clear, orderly steps to follow. It is assumed the user understands the meaning of "sautee the onions" or "bake until golden brown." Some context like "the dough will be sticky" may be added for things that  differ from what the user expects. For the most part though, the required items and steps will get the job done.
+
+Some example how-to guide section names per project are as follows:
+
+| Project  | How-to guide section |
+|:---------|:---------------------|
+| Moonbeam | Builders             |
+| Polkadot | Develop              |
+| Tanssi   | Builders             |
+| Wormhole | Build                |
+
+#### Wormhole
+
+- [**Build page template guide**](/papermoon-mkdocs/style-guide/key-resources/templates/wormhole/build-pages/)
+- [**Build page template**](/papermoon-mkdocs/style-guide/key-resources/templates/wormhole/build-pages/#build-page-template)
 
 ### Tutorial
 
+:construction: :construction_worker_tone3: :soon: :tm:
+
 ### Reference
+
+:construction: :construction_worker_tone3: :soon: :tm:
 
 ### Index Pages
 
@@ -32,6 +66,12 @@ The use of index pages is under review. Expect changes and updates to this guida
 #### Wormhole
 - [**Index page template guide**](/papermoon-mkdocs/style-guide/key-resources/templates/wormhole/index-pages/)
 - [**Index page template**](/papermoon-mkdocs/style-guide/key-resources/templates/wormhole/index-pages/#index-page-template)
+
+## Additional Resources
+
+- [**Template Guides**](https://www.thegooddocsproject.dev/template){target=\_blank} - learn more about each template type with these guides from The Good Docs Project
+- [**The difference between a tutorial and how-to guide**](https://diataxis.fr/tutorials-how-to/){target=\_blank} - explore how Diataxis compares the two documentation types
+- [**The difference between reference and explanation**](https://diataxis.fr/reference-explanation/){target=\_blank} - explore how Diataxis compares the two documentation types
 
 
 

--- a/papermoon-docs/style-guide/key-resources/templates/index.md
+++ b/papermoon-docs/style-guide/key-resources/templates/index.md
@@ -13,9 +13,7 @@ In this section you will find templates for the four primary documenation types 
 
 ## How-To Use the Templates
 
-Deciding which template best fits the content you want to create can be tricky, especially when it comes to differentiating tutorials from how-to guides. 
-
-<!--Mermaid diagram here for selecting template-->
+Deciding which template best fits the content you want to create can be tricky, especially when it comes to differentiating tutorials from how-to guides.
 
 ## Available Templates
 
@@ -26,6 +24,14 @@ Deciding which template best fits the content you want to create can be tricky, 
 ### Tutorial
 
 ### Reference
+
+### Index Pages
+
+The use of index pages is under review. Expect changes and updates to this guidance. 
+
+#### Wormhole
+- [**Index page template guide**](/papermoon-mkdocs/style-guide/key-resources/templates/wormhole/index-pages/)
+- [**Index page template**](/papermoon-mkdocs/style-guide/key-resources/templates/wormhole/index-pages/#index-page-template)
 
 
 

--- a/papermoon-docs/style-guide/key-resources/templates/wormhole/build-pages.md
+++ b/papermoon-docs/style-guide/key-resources/templates/wormhole/build-pages.md
@@ -4,3 +4,188 @@ description: TODO
 ---
 
 # Wormhole Build Pages
+
+## Introduction
+
+The Wormhole Docs use Build as the section for how-to guide related content. Build pages are structured to implement the [How-to guide](https://diataxis.fr/how-to-guides/){target=\_blank} Diataxis documentation form and the [How-to guide](https://www.thegooddocsproject.dev/template/how-to){target=\_blank} The Good Docs Project content type. The following sections use task to refer to the objective the user wants to acheive by using the how-to guide.
+
+## Purpose of Build Pages
+
+The primary purpose of Build pages is to help the user solve a real-world problem or complete a task. Consider the following guidelines when planning a Build page:
+
+:white_check_mark: Take the user through a series of steps for the surest and safest way to solve a problem, complete a task, or troubleshoot an issue
+
+:white_check_mark: Clearly and concisely describe a set of sequential steps the user must complete to accomplish the goal
+
+:white_check_mark: Build page how-to guides assume the user has basic knowledge of blockchain development and Wormhole concepts
+
+:white_check_mark: Alert the user to possible issues or difficulties and provide guidance on resolving them
+
+:x: Do not include conceptual explation or reference information in the body copy
+
+## Before You Start Writing
+
+The single most important thing you can do before you start writing is to think about the target audience and what they might need from this page. The following sections contain additional activities you may find useful during the planning phase.
+
+### Identify Scenarios
+
+Once you identify the task the Build page will cover, it is helpful to consider different scenarios your user may encounter when carrying out the task in the real world. The best way to do this is to walk through the task yourself. You should make sure you've completed the task and understand the places where a user might have questions or decision points requiring guidance. 
+
+### Map the Safest Path
+
+There is often more than one possible way to complete a task. Your goal as the creator of the Build page is to map out the safest, surest path to completing the task. Suggesting multiple ways to complete a task asks the user to analyze those options, understand them all, and determine which option will best solve their problem. Make their journey easier and provide a single, reliable path to accomplishing the task. 
+
+### Anticipate Error Scenarios
+
+Keep track of any errors you encounter while working through the task and identifying scenarios. Your Build page should include troubleshooting information anywhere you anticipate the user may encounter errors.
+
+## Name a Build Page
+
+The title of a Build page should tell the user what task they can accomplish by following the guide. Consider the following guidelines and options when naming a Build page:
+
+- **Use a Verb** - start the title with the plain, or base, form of a verb such as "Build," "Integrate", or "Configure"
+
+    :white_check_mark: Send Messages with Wormhole Relayer
+
+    :white_check_mark: Interact with CCTP Contracts
+
+- **Avoid Use of Present Participles** - also known as gerunds, the "-ing" form of verbs makes content more challenging to translate and, therefore, decreases accessibility
+
+    :x: Building Cross-Chain Applications
+
+    :x: Integrating Smart Contracts
+
+- **Communicate the Task** - the page title should tell the user what the guide will help them accomplish as completely as possible
+
+    :white_check_mark: Run a Custom Relayer
+
+    :white_check_mark: Upgrade Contracts
+
+    :x: Deployment
+
+- **Meta title** - each Learn page must include an SEO-friendly meta title of between 34 and 44 characters
+
+    :white_check_mark: The meta title combined with "| Womrhole Docs" should total between 50 and 60 characters 
+
+    :white_check_mark: The title in the left navigation and the title rendered on the page can be different
+
+If you have a title you would like to use that doesn't fit these guidelines, please discuss it with the formatting team prior to opening your pull request. 
+
+## Create Build Page Description
+
+Each Build page must include an an SEO-friendly meta-description of between 120 and 160 characters. You can use Grammarly as an assistant for this task by following these steps:
+
+1. Paste your copy into a Grammarly document
+2. Select the **Write with generative AI** tab at the top of the right-hand column
+3. Use a prompt similar to the following:
+
+    ```text
+    Please create an SEO-friendly description between 120 and 160 characters for this page
+    ```
+
+4. Make any needed adjustments to the generated text and add it to the description field of your document
+
+## Name a Subtask
+
+As you name the subtasks within your Build page to create section headings, consider the following guidelines:
+
+- **Consider SEO** - keep these headings informative to improve SEO performance, discoverability, and accessibility
+
+- **Use a Verb** - similar to the page title, headings should use plain or base forms of verbs
+
+- **Create an Outline** - create an outline using just the headings for the subtasks and review it to ensure the user can readily determine the upcoming activities using the headings alone
+
+## Style Guidance
+
+All Wormhole Build pages should include the following:
+
+- **SEO-friendly meta title** - between 34 and 44 characters. This title plus the copy "| Wormhole Docs" should equal 50 to 60 characters in total
+- **SEO-friendly meta description** - between 120 and 160 characters
+- **H1 heading page title** - this is the title that will render at the top of the page and may be different than the meta title
+- **Content or body text** - all Build pages should help the user solve a real-world problem or complete a task. The following elements contribute to a quality Build page:
+    
+### Introduction 
+
+Your opening paragraph should include the following: 
+
+- a clear description of the task completed in the guide 
+- when and why the user might want to perform the task
+
+Example - see the [introduction](https://docs.stripe.com/no-code/subscriptions){target=\_blank} from the Create subscriptions page of the Stripe docs
+
+### Prerequisites
+
+The Prerequisites section should include a statement advising the user of which items the Build page assumes they have basic knowledge, including knowledge of basic blockchain development and Wormhole concepts. Following this statement, include a bullet list of additional things the user needs to know, install, or have available. This might include items such as the following:
+
+- Specific Wormhole concepts they should know with links to related Learn pages
+- Software or hardware requirements
+- Environments to set up and configure
+- Testnet tokens or wallets
+- Authentication and authorization information such as API or private keys
+
+Wherever possible, link the user to a resource to help them complete a prerequisite. This can include outside documentation, relevant Learn pages, token faucets, and similar.
+
+Example - see the following for an example of a quality prerequisites section:
+
+- [Prerequisites](https://wormhole.com/docs/build/contract-integrations/core-contracts/#prerequisites){target=\_blank} section of Get Started with Core Contracts in the Wormhole docs
+- [Prequisites](https://docs.polkadot.com/tutorials/polkadot-sdk/parachains/zero-to-hero/obtain-coretime/#prerequisites){target=\_blank} section of Obtain Coretime in the Polkadot docs
+
+### Style Subtasks
+
+For each subtask in the guide, use the heading to list the name of the subtask followed by a numbered list of steps to follow to complete that task. For each numbered step, include the following:
+
+- **Action to take** - start with a verb 
+
+    :white_check_mark: 1. Create a new folder
+
+- **Explanatory text** - should be minimal and concise 
+
+    :white_check_mark: Use the following commands to create a new folder:
+
+- **Code sample or screenshot** - (optional) add when a visual aide can help the user better understand the step
+
+    :white_check_mark: Include the name of the file by adding `title="filename.extension"` to the top code fence similar to:
+
+    ```text
+    ```javascript title="filename.js"
+    ```
+
+- **Result** - (optional) where appropriate, tell the user what they can expect if they performed the step correctly
+
+    :white_check_mark: If successful, you will see terminal output similar to the following:
+
+Example - see the following for an example of documenting a subtask:
+
+- [Create a subscription](https://docs.stripe.com/no-code/subscriptions#create-subscriptions){target=\_blank} task in the Stripe docs
+
+### Related Resources 
+
+Create a bulleted list of links to informational resources related to the page contents, such as Learn pages, source code, or relevant Reference page entries. 
+
+### Where to Go Next
+
+Create a bulleted list of guides and tutorials related to the page contents to guide the developer journey toward completing related tasks.
+
+## Build Page Template
+
+--8<-- 'code/style-guide/key-resources/templates/wormhole/index-pages/wh-build-template.md'
+
+## PR Checklist
+
+Before requesting PR review, please ensure you have:
+
+1. Used Grammarly to review your work and made edits as needed
+2. Served the site locally for a visual review of rendering and made updates as needed
+
+    You can serve the site locally by running the following command from the `wormhole-mkdocs` directory:
+
+    ```bash
+    mkdocs serve
+    ```
+
+3. Checked the PR checklist on GitHub and completed any items listed there
+
+## Addtional Resources
+
+- [**Character Counter**](https://wordcounter.net/character-count){target=\_blank} - quickly check the character length of your titles and descriptions
+- [**Title Case Converter**](https://titlecaseconverter.com/){target=\_blank} - verify title case for titles or headlines

--- a/papermoon-docs/style-guide/key-resources/templates/wormhole/index-pages.md
+++ b/papermoon-docs/style-guide/key-resources/templates/wormhole/index-pages.md
@@ -24,18 +24,12 @@ All Wormhole index pages should include the following items:
 - **SEO-friendly meta title** - between 34 and 44 characters. This title plus the copy "| Wormhole Docs" should equal 50 to 60 characters in total
 - **SEO-friendly meta description** - between 120 and 160 characters
 - **H1 heading page title** - this is the title that will render at the top of the page and may be different than the meta title
-- **Content or body text** - this will be different for each page. All index pages should do guide the user journey and, when appropriate, describe products or use cases
-    - **User journey** - all index pages are part of the roadmap to guide the user along their journey. See [Develop User Journey](#develop-user-journey) in the following section for guidance on formatting user journey related content
-    - **Product description** - if the page links to one or more products, add a project description for each product. See [Describe a Product](#describe-a-product) in the following section for guidance on formatting product descriptions
+- **Content or body text** - this will be different for each page. All index pages should guide the user journey and, when appropriate, describe products or use cases
+    - **User journey** - all index pages are part of the roadmap to guide the user along their journey in discovering and using the product
+    - **Product description** - if the page links to one or more products, add a project description for each product
 - **Cards for navigation links** - these cards should match the navigation options for the page
 - **Related Resources** (optional) - bulleted list of informational resources related to the page contents or relevant Reference page entries
 - **Where to Go Next** (optional) - bulleted list of guides and tutorials related to the page contents
-
-## Develop User Journey
-
-## Describe a Product
-
-
 
 ## Index Page Template
 
@@ -65,10 +59,8 @@ Before requesting PR review, please ensure you have:
 
 ## Addtional Resources
 
-
-
-## Next Steps
-
+- [**Character Counter**](https://wordcounter.net/character-count) - quickly check the character length of your titles and descriptions
+- [**Title Case Converter**](https://titlecaseconverter.com/) - verify title case for titles or headlines
 
 
 

--- a/papermoon-docs/style-guide/key-resources/templates/wormhole/learn-pages.md
+++ b/papermoon-docs/style-guide/key-resources/templates/wormhole/learn-pages.md
@@ -7,12 +7,173 @@ description: TODO
 
 ## Introduction
 
+The Wormhole Docs use Learn as the section for informational content. Learn pages are structured to implement the [Explanation](https://diataxis.fr/explanation/){target=\_blank} Diataxis documentation form and the [Concept](https://www.thegooddocsproject.dev/template/concept){target=\_blank} The Good Docs Project content type. The following sections use concept to refer to the topic or idea your content is about.
+
 ## Purpose of Learn Pages
+
+The primary purpose of Learn pages is to develop the user's understanding of the concept. Consider the following guidelines when planning a Learn page:
+
+:white_check_mark: Provide clear, concise, and consistent information about a specific concept or process
+
+:white_check_mark: Give the user context that will help in understanding the more specific content ahead
+
+:white_check_mark: Explain the context and components of a tool or product and how they fit into the broader framework
+
+:x: Do not include how-to steps or reference information in the body copy
 
 ## Before You Start Writing
 
+The single most important thing you can do before you start writing is to think about the target audience and what they might need from this page. The following sections contain additional activities you may find useful during the planning phase. 
+
+### Map Out the Concept
+
+Use a sketch, diagram, or outline to help you to organize the information in your mind and see the entire concept at once. Possible questions to answer during this step include:
+
+- How does the concept connect to other concepts?
+- Where does it fit in the broader ecosystem?
+- What dependencies exist? Are there concepts a user should know before they read this content?
+
+If you do this part well, you may come away with the start of a nice diagram or visual aid for your page.
+
+### Collect User Feedback 
+
+User feedback can be a powerful tool in shaping documentation to best meet user needs. Collect common questions or concerns where possible and use them to guide your content development. Possible sources of feedback might include:
+
+- Submissions to the feedback widget
+- Hackathon participant feedback
+- GitHub issues on project repositories
+- Developer discussions in places like Discord and Telegram
+
+### Organize Information
+
+Use the inverted pyramid structure to organize Learn page information. With the inverted pyramid, the information the user most needs to know is presented first. The rest of the information is ordered from most important to least important. 
+
+The [Inverted pyramid structure](https://www.stylemanual.gov.au/structuring-content/types-structure/inverted-pyramid-structure){target=\_blank} page from the Australian Government Style Manual provides a deeper look at effective use of the inverted pyramid.
+
 ## Name a Learn Page
+
+The title of a Learn page is your first opportunity to help the user identify the topic of the page. Consider the following guidelines and options when naming a Learn page:
+
+- **Name of concept** - use the name of the concept as a noun
+
+    :white_check_mark: Token Bridge, Core Contracts, and similar
+
+- **Overview** - overview page titles should typically include the topic or concept
+
+    :white_check_mark: Overview of Transfer Protocols
+
+    :white_check_mark: Transfer Protocol Overview
+
+    :x: Avoid using Overview by itself as a page title
+
+- **Introduction** - introduction page titles should typically include the topic or concept
+
+    :white_check_mark: Introduction to Wormhole
+
+    :white_check_mark: Introduction to Multichain Applications
+
+    :x: Introduction
+
+- **Meta title** - each Learn page must include an SEO-friendly meta title of between 34 and 44 characters
+
+    :white_check_mark: The meta title combined with "| Womrhole Docs" should total between 50 and 60 characters 
+
+    :white_check_mark: The title in the left navigation and the title rendered on the page can be different
+
+If you have a title you would like to use that doesn't fit these guidelines, please discuss it with the formatting team prior to opening your pull request. 
 
 ## Create Learn Page Description
 
-## Page Content
+Each Learn page must include an an SEO-friendly meta-description of between 120 and 160 characters. You can use Grammarly as an assistant for this task by following these steps:
+
+1. Paste your copy into a Grammarly document
+2. Select the **Write with generative AI** tab at the top of the right-hand column
+3. Use a prompt similar to the following:
+
+    ```text
+    Please create an SEO-friendly description between 120 and 160 characters for this page
+    ```
+
+4. Make any needed adjustments to the generated text and add it to the description field of your document
+
+## Style Guidance
+
+All Wormhole Learn pages should include the following:
+
+- **SEO-friendly meta title** - between 34 and 44 characters. This title plus the copy "| Wormhole Docs" should equal 50 to 60 characters in total
+- **SEO-friendly meta description** - between 120 and 160 characters
+- **H1 heading page title** - this is the title that will render at the top of the page and may be different than the meta title
+- **Content or body text** - all Learn pages should increase the user's understanding of the concept and provide needed context for the more specific content they will eventually encounter. The following elements contribute to a quality Learn page:
+    
+### Introduction 
+
+Your opening paragraph should immediately tell the user if this page is of interest or use to them. Consider the following guidance when writing the first paragraph of the introduction:
+
+- Introduce the concept. What is it?
+- Provide context. Why is it important or relevant? 
+- Preview upcoming content. What will the user find here?
+
+Examples - see the following for examples of quality opening paragraphs:
+
+- [Introduction to the DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Introduction){target=\_blank} page of MDN 
+- [Core Contracts]({target=\_blank}){target=\_blank} page of Wormhole Docs
+
+Following the opening paragraph, add one to two paragraphs to address the following points where relevant:
+
+- **Functionality** - what does the product or concept do?
+- **Define the Concept** - think of a glossary definition. The goal is to create a shared understanding of the concept between the writer and reader
+- **The Big Picture** - explain how this concept fits into the bigger picture of products or concepts. Focus language on the problem solved and benefits of the solution 
+- **Key Features** - a bullet list of key features can be helpful here
+- **Visual Aid or Diagram** (optional) - use if it will help illustrate how the concept is organized or how it fits into the broader system or product
+
+Example - see the following for an example of defining a concept:
+
+- [Processor](https://cloud.google.com/document-ai/docs/overview#dai-processors){target=\_blank} section of the Google Cloud Document AI documentation
+
+### Use Cases
+
+This is a great opportunity to link users to future steps in the developer journey. Depending on the overall length of the Learn page, use paragraphs or bullet lists to briefly share use cases related to the concept or product. A quality use case will include a brief explanation of the problem being solved and specifically how the presented concept solves the problem.
+
+Example - see the following for an example of defining use cases:
+
+- [Document AI components](https://cloud.google.com/document-ai/docs/overview#components){target=\_blank} section of the Google Cloud Document AI documentation
+
+### Comparison Section (optional)
+
+Use this section to include a comparison table, or link to one elsewhere on the site, if appropriate. 
+
+### How It Works
+
+Includes one to two paragraphs to briefly explain how the concept operates and the main components involved in any associated process. This is where you can go into more detail for those who have read this far down the page. 
+
+### Related Resources 
+
+Create a bulleted list of links to informational resources related to the page contents or relevant Reference page entries. 
+
+### Where to Go Next
+
+Create a bulleted list of guides and tutorials related to the page contents to guide the developer journey toward using what they learned.
+
+## Learn Page Template
+
+--8<-- 'code/style-guide/key-resources/templates/wormhole/index-pages/wh-learn-template.md'
+
+## PR Checklist
+
+Before requesting PR review, please ensure you have:
+
+1. Used Grammarly to review your work and made needed edits as appropriate
+2. Served the site locally for a visual review of rendering and made updates as needed. 
+
+    You can serve the site locally by running the following command from the `wormhole-mkdocs` directory:
+
+    ```bash
+    mkdocs serve
+    ```
+
+3. Checked the PR checklist on GitHub and completed any items listed there
+
+## Addtional Resources
+
+- [**Character Counter**](https://wordcounter.net/character-count){target=\_blank} - quickly check the character length of your titles and descriptions
+- [**Title Case Converter**](https://titlecaseconverter.com/){target=\_blank} - verify title case for titles or headlines

--- a/papermoon-docs/style-guide/key-resources/templates/wormhole/learn-pages.md
+++ b/papermoon-docs/style-guide/key-resources/templates/wormhole/learn-pages.md
@@ -162,8 +162,8 @@ Create a bulleted list of guides and tutorials related to the page contents to g
 
 Before requesting PR review, please ensure you have:
 
-1. Used Grammarly to review your work and made needed edits as appropriate
-2. Served the site locally for a visual review of rendering and made updates as needed. 
+1. Used Grammarly to review your work and made edits as needed
+2. Served the site locally for a visual review of rendering and made updates as needed
 
     You can serve the site locally by running the following command from the `wormhole-mkdocs` directory:
 


### PR DESCRIPTION
This PR does the following:

- creates md file templates for WH build, learn, and index pages
- creates a usage guide for each new template
- embeds and copy & paste snippet of each template on its matching page
- creates an index page with guidance on template selection and links to existing templates